### PR TITLE
Add dates for Suri et al and Fleischmann and Vybornova in bibliography

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -46,9 +46,11 @@ Citation Key: morgan{\_}travel{\_}2020}
 	note = {Citation Key: R-stplanr}
 }
 
-@article{suri,
+@article{suri2021,
 	title = {Ember: No-Code Context Enrichment via Similarity-Based Keyless Joins},
 	author = {Suri, Sahaana and Ilyas, Ihab F. and {Ré}, Christopher and Rekatsinas, Theodoros},
+    year = {2021},
+    date = {2021-11-01},
 	doi = {10.14778/3494124.3494149}
 }
 
@@ -136,9 +138,11 @@ Publisher: Routledge
 	note = {Publisher: Elsevier}
 }
 
-@article{fleischmann,
+@article{fleischmann2024,
 	title = {A shape-based heuristic for the detection of urban block artifacts in street networks},
 	author = {Fleischmann, Martin and Vybornova, Anastassia},
+    year = {2024},
+    date = {2024-06-27},
 	doi = {10.5311/JOSIS.2024.28.319},
 	langid = {en}
 }


### PR DESCRIPTION
Update bibliography with dates based on journal references for Suri et al and Fleischmann and Vybornova as currently showing as "n.d."